### PR TITLE
Fix the wrong size of the array of gradients

### DIFF
--- a/src/lib/simplex_noise.cc
+++ b/src/lib/simplex_noise.cc
@@ -41,7 +41,7 @@ namespace mm {
 
   }
 
-  static const vector2 s_gradients[12] = {
+  static const vector2 s_gradients[8] = {
     { -1.0, -1.0 },
     {  1.0,  0.0 },
     { -1.0,  0.0 },
@@ -54,7 +54,7 @@ namespace mm {
 
   const vector2& simplex_noise::grid(uint8_t i, uint8_t j) const {
     uint8_t index = i + m_perm.at(j);
-    return s_gradients[index % 12];
+    return s_gradients[index % 8];
   }
 
   static const double K = .366025403784438646763723170752; // (sqrt(3) - 1) / 2


### PR DESCRIPTION
- s_gradients array was specified of size 12, and used with a modulus 12,
  but is only filled with 8 gradient vectors !
  => if the rest of the array is filled with zeros,
    this degrades the variety of the noise produced
- I believe the error comes from having converted a 3D implementation,
  where 12 gradients are used (for standard implementation)
- And by the way, using a modulus 8 is much more optimzed by the compiler :)
